### PR TITLE
Allow absolute paths in the tags file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,8 +42,8 @@ function reindexScope(stash, scope) {
         reader.on("line", (line) => {
             if (line.startsWith("!")) return;
 
-            const [symbol, relativePath, ...rest] = line.split("\t");
-            const file = vscode.Uri.joinPath(scope.uri, relativePath);
+            const [symbol, path, ...rest] = line.split("\t");
+            const file = path.startsWith('/') ? vscode.Uri.parse(path) : vscode.Uri.joinPath(scope.uri, path);
             const lineNumberStr = rest.find(value => value.startsWith("line:")).substring(5);
             const lineNumber = parseInt(lineNumberStr, 10) - 1;
             const kind = rest.find(value => value.startsWith("kind:")).substring(5);
@@ -56,8 +56,8 @@ function reindexScope(stash, scope) {
             if (!symbolIndex.hasOwnProperty(symbol)) symbolIndex[symbol] = [];
             symbolIndex[symbol].push(definition);
 
-            if (!documentIndex.hasOwnProperty(relativePath)) documentIndex[relativePath] = [];
-            documentIndex[relativePath].push(definition);
+            if (!documentIndex.hasOwnProperty(path)) documentIndex[path] = [];
+            documentIndex[path].push(definition);
         });
 
         reader.on("close", () => {

--- a/src/tests.js
+++ b/src/tests.js
@@ -44,6 +44,10 @@ async function testCtagsDefinitionProvider(stash, document) {
 
     const printDefinitions = await provider.provideDefinition(document, new vscode.Position(4, 7));
     assert(() => printDefinitions === undefined);
+
+    const [externalLibDefinition] = await provider.provideDefinition(document, new vscode.Position(17, 6));
+    assert(() => externalLibDefinition.uri.path === '/usr/lib/pyhon/external_lib.py');
+    assert(() => externalLibDefinition.range.start.line === 21);
 }
 
 async function testCtagsDocumentSymbolProvider(stash, document) {

--- a/test_projects/python/.vscode/.tags
+++ b/test_projects/python/.vscode/.tags
@@ -9,3 +9,4 @@ Klass	source.py	/^class Klass:$/;"	kind:class	line:8
 funktion	source.py	/^def funktion(value):$/;"	kind:function	line:4
 method	source.py	/^    def method(self):$/;"	kind:member	line:9	class:Klass
 method_with_underscores	source.py	/^    def method_with_underscores(self):$/;"	kind:member	line:12	class:Klass
+ExternalLib	/usr/lib/pyhon/external_lib.py	/^class ExternalLib:$/;"	kind:class	line:22

--- a/test_projects/python/source.py
+++ b/test_projects/python/source.py
@@ -15,3 +15,4 @@ class Klass:
 
 Klass().method()
 Klass().method_with_underscores()
+ExternalLib()


### PR DESCRIPTION
Hi, @gediminasz 
First of all, thank you for your work on this extension. It is pretty useful. 
My pull request allows the tags file to refer to external libs using absolute paths. Because currently, reindexScope joins path with the scope.uri, despite its type, resulting in the wrong address. 
The solution comes with a test assertion.