### PR TITLE
Warn user about missing ctags command setting

### DIFF
--- a/src/__mocks__/vscode.js
+++ b/src/__mocks__/vscode.js
@@ -28,6 +28,10 @@ const workspace = {
 console.assert(workspace.asRelativePath({ fsPath: "/test/foo" }) == "foo");
 console.assert(workspace.asRelativePath({ fsPath: "/elsewhere/bar" }) == "/elsewhere/bar");
 
+const window = {
+  showErrorMessage: jest.fn(),
+};
+
 function Position(line, character) {
     return { line, character };
 }
@@ -45,4 +49,4 @@ const Uri = {
     joinPath: (left, right) => path.join(left.fsPath, right)
 };
 
-module.exports = { SymbolKind, workspace, Position, Location, SymbolInformation, Uri };
+module.exports = { SymbolKind, workspace, window, Position, Location, SymbolInformation, Uri };

--- a/src/extension.js
+++ b/src/extension.js
@@ -4,7 +4,7 @@ const { CtagsDefinitionProvider } = require("./providers/ctags_definition_provid
 const { CtagsDocumentSymbolProvider } = require("./providers/ctags_document_symbol_provider");
 const { CtagsWorkspaceSymbolProvider } = require("./providers/ctags_workspace_symbol_provider");
 const { EXTENSION_ID, EXTENSION_NAME, TASK_NAME } = require("./constants");
-const { getConfiguration } = require("./helpers");
+const { getConfiguration, commandGuard} = require("./helpers");
 const { reindexAll, reindexScope } = require("./index");
 const { runTests } = require("./tests");
 
@@ -53,6 +53,7 @@ function activate(context) {
                 vscode.tasks.registerTaskProvider("shell", {
                     provideTasks: () => {
                         const command = getConfiguration(scope).get("command");
+                        if (commandGuard(command)) return [];
                         const task = new vscode.Task(
                             { type: "shell" },
                             scope,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,6 +1,6 @@
 const vscode = require("vscode");
 
-const { EXTENSION_ID } = require("./constants");
+const { EXTENSION_ID, EXTENSION_NAME } = require("./constants");
 
 function determineScope(document) {
     return vscode.workspace.workspaceFolders.find(scope => document.uri.fsPath.includes(scope.uri.fsPath));
@@ -8,6 +8,17 @@ function determineScope(document) {
 
 function getConfiguration(scope = null) {
     return vscode.workspace.getConfiguration(EXTENSION_ID, scope);
+}
+
+function commandGuard(command) {
+    if ( typeof command !== 'string' || command.trim() === '')  {
+        vscode.window.showErrorMessage(
+            `${EXTENSION_NAME}: The "Command" preference is not set. Please check your configuration.`
+        )
+        return true
+    }
+
+    return false
 }
 
 const SYMBOL_KINDS = {
@@ -74,4 +85,4 @@ function definitionToSymbolInformation({ symbol, file, line, kind, container }) 
     );
 }
 
-module.exports = { determineScope, getConfiguration, definitionToSymbolInformation };
+module.exports = { determineScope, getConfiguration, commandGuard, definitionToSymbolInformation };

--- a/src/helpers.test.js
+++ b/src/helpers.test.js
@@ -1,7 +1,6 @@
 const vscode = require("vscode");
 
-const { definitionToSymbolInformation } = require("./helpers");
-
+const { definitionToSymbolInformation, commandGuard } = require("./helpers");
 
 describe("definitionToSymbolInformation", () => {
     it.each([
@@ -25,3 +24,17 @@ describe("definitionToSymbolInformation", () => {
         expect(symbolInformation.kind).toEqual(vscodeKind);
     });
 });
+
+describe('commandGuard', () => {
+    it('silent when command is present', () => {
+        expect(commandGuard("/bin/ctags")).toEqual(false);
+        expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
+    })
+
+    it.each([undefined, '', '  '])("params that cause error message", param => {
+        expect(commandGuard(param)).toEqual(true);
+        expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+            'Ctags Companion: The "Command" preference is not set. Please check your configuration.'
+        );
+    })
+})


### PR DESCRIPTION
Today, while rapidly switching between the projects, I found that the extension did not give me the task option to generate ctags. And instead of checking my config, I started looking through the extension code to find what was wrong. After a while, I found that the "Command" setting somehow become empty. So I desided that this can be good to have a warning message that will let you know about this kind of problem.
