### PR TITLE
Fixed symbols matching certain JS methods breaking the extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Improved performance of tags file parsing.
+- Fixed a bug when symbols matching certain JS methods (e.g. `hasOwnProperty`) would break the extension. Thanks to @ocoka for reporting!
 
 ## 2021.1.0
 

--- a/src/__mocks__/vscode.js
+++ b/src/__mocks__/vscode.js
@@ -52,4 +52,16 @@ const Uri = {
     joinPath: (left, right) => path.join(left.fsPath, right)
 };
 
-module.exports = { SymbolKind, workspace, window, Position, Location, SymbolInformation, Uri };
+class Memento {
+    constructor() {
+        this.state = {};
+    }
+    get(key) {
+        return this.state[key];
+    }
+    update(key, value) {
+        this.state[key] = value;
+    }
+}
+
+module.exports = { SymbolKind, workspace, window, Position, Location, SymbolInformation, Uri, Memento };

--- a/src/index.js
+++ b/src/index.js
@@ -36,24 +36,24 @@ function reindexScope(stash, scope, { fs = fs_, readline = readline_ } = {}) {
         const input = fs.createReadStream(tagsPath);
         const reader = readline.createInterface({ input, terminal: false, crlfDelay: Infinity });
 
-        const symbolIndex = {};
-        const documentIndex = {};
+        const symbolIndex = new Map();
+        const documentIndex = new Map();
 
         reader.on("line", (line) => {
             if (line.startsWith("!")) return;
 
             const [symbol, path, ...rest] = line.split("\t");
 
-            if (!symbolIndex.hasOwnProperty(symbol)) symbolIndex[symbol] = [];
-            symbolIndex[symbol].push(line);
+            if (!symbolIndex.has(symbol)) symbolIndex.set(symbol, []);
+            symbolIndex.get(symbol).push(line);
 
-            if (!documentIndex.hasOwnProperty(path)) documentIndex[path] = [];
-            documentIndex[path].push(line);
+            if (!documentIndex.has(path)) documentIndex.set(path, []);
+            documentIndex.get(path).push(line);
         });
 
         reader.on("close", () => {
-            const indexes = stash.context.workspaceState.get("indexes") || {};
-            indexes[scope.uri.fsPath] = { symbolIndex, documentIndex };
+            const indexes = stash.context.workspaceState.get("indexes") || {};  // TODO use Map here as well
+            indexes[scope.uri.fsPath] = { symbolIndex: [...symbolIndex], documentIndex: [...documentIndex] };
             stash.context.workspaceState.update("indexes", indexes);
 
             stash.statusBarItem.hide();

--- a/src/index.js
+++ b/src/index.js
@@ -13,10 +13,12 @@ async function getIndexForScope(stash, scope) {
 }
 
 async function reindexAll(stash) {
-    await Promise.all(vscode.workspace.workspaceFolders.map(scope => reindexScope(stash, scope)));
+    vscode.workspace.workspaceFolders.map(scope => reindexScope(stash, scope));
 }
 
 function reindexScope(stash, scope, { fs = fs_ } = {}) {
+    console.time("[Ctags Companion] reindex");
+
     const tagsPath = path.join(scope.uri.fsPath, getConfiguration(scope).get("path"));
 
     if (!fs.existsSync(tagsPath)) {
@@ -28,22 +30,18 @@ function reindexScope(stash, scope, { fs = fs_ } = {}) {
         return;
     }
 
-    return new Promise(resolve => {
-        console.time("[Ctags Companion] reindex");
-        stash.statusBarItem.text = `$(refresh) Ctags Companion: reindexing ${scope.name}...`;
-        stash.statusBarItem.show();
+    stash.statusBarItem.text = `$(refresh) Ctags Companion: reindexing ${scope.name}...`;
+    stash.statusBarItem.show();
 
-        const lines = fs.readFileSync(tagsPath, { encoding: "utf-8" }).trim().split("\n");
+    const lines = fs.readFileSync(tagsPath, { encoding: "utf-8" }).trim().split("\n");
 
-        const indexes = stash.context.workspaceState.get("indexes") || {};  // TODO use Map here as well
-        indexes[scope.uri.fsPath] = createIndex(lines);
-        stash.context.workspaceState.update("indexes", indexes);
+    const indexes = stash.context.workspaceState.get("indexes") || {};  // TODO use Map here as well
+    indexes[scope.uri.fsPath] = createIndex(lines);
+    stash.context.workspaceState.update("indexes", indexes);
 
-        stash.statusBarItem.hide();
-        console.timeEnd("[Ctags Companion] reindex");
+    stash.statusBarItem.hide();
 
-        resolve();
-    });
+    console.timeEnd("[Ctags Companion] reindex");
 }
 
 function createIndex(lines) {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,16 +1,7 @@
+const vscode = require("vscode");
+
 const { reindexScope } = require("./index");
 
-class MockMemento {
-    constructor() {
-        this.state = {};
-    }
-    get(key) {
-        return this.state[key];
-    }
-    update(key, value) {
-        this.state[key] = value;
-    }
-}
 
 class MockStatusBarItem {
     constructor() {
@@ -32,7 +23,7 @@ describe("reindexScope", () => {
 
     it("shows a warning when file does not exist", () => {
         const stash = {
-            context: { workspaceState: new MockMemento() },
+            context: { workspaceState: new vscode.Memento() },
             statusBarItem: new MockStatusBarItem()
         };
         const fs = {
@@ -59,7 +50,7 @@ describe("reindexScope", () => {
 
         it("indicates activity in status bar", () => {
             const stash = {
-                context: { workspaceState: new MockMemento() },
+                context: { workspaceState: new vscode.Memento() },
                 statusBarItem: new MockStatusBarItem()
             };
 
@@ -72,7 +63,7 @@ describe("reindexScope", () => {
 
         it("skips meta lines", () => {
             const stash = {
-                context: { workspaceState: new MockMemento() },
+                context: { workspaceState: new vscode.Memento() },
                 statusBarItem: new MockStatusBarItem()
             };
 
@@ -107,7 +98,7 @@ describe("reindexScope", () => {
             ],
         ])("indexes tags", (line, expectedSymbol, expectedPath) => {
             const stash = {
-                context: { workspaceState: new MockMemento() },
+                context: { workspaceState: new vscode.Memento() },
                 statusBarItem: new MockStatusBarItem()
             };
 
@@ -125,7 +116,7 @@ describe("reindexScope", () => {
 
         it("appends to already indexed symbols", () => {
             const stash = {
-                context: { workspaceState: new MockMemento() },
+                context: { workspaceState: new vscode.Memento() },
                 statusBarItem: new MockStatusBarItem()
             };
 
@@ -152,7 +143,7 @@ describe("reindexScope", () => {
 
         it("appends to already indexed documents", () => {
             const stash = {
-                context: { workspaceState: new MockMemento() },
+                context: { workspaceState: new vscode.Memento() },
                 statusBarItem: new MockStatusBarItem()
             };
 
@@ -179,7 +170,7 @@ describe("reindexScope", () => {
 
         it("does not clash with built-in properties", () => {
             const stash = {
-                context: { workspaceState: new MockMemento() },
+                context: { workspaceState: new vscode.Memento() },
                 statusBarItem: new MockStatusBarItem()
             };
 

--- a/src/providers/ctags_definition_provider.js
+++ b/src/providers/ctags_definition_provider.js
@@ -11,7 +11,7 @@ class CtagsDefinitionProvider {
         const scope = determineScope(document);
         const { symbolIndex } = await getIndexForScope(this.stash, scope);
 
-        const definitions = symbolIndex[symbol];
+        const definitions = new Map(symbolIndex).get(symbol);
         if (definitions) {
             return definitions
                 .map(definition => definitionToSymbolInformation(definition, scope))

--- a/src/providers/ctags_definition_provider.test.js
+++ b/src/providers/ctags_definition_provider.test.js
@@ -27,10 +27,10 @@ describe(CtagsDefinitionProvider, () => {
                             case "indexes":
                                 return {
                                     "/test": {
-                                        symbolIndex: {
-                                            emptyListSymbol: [],
-                                            foo: ['foo	src.py	/^    def foo(self):$/;"	kind:member	line:32	class:Goo']
-                                        }
+                                        symbolIndex: [
+                                            ["emptyListSymbol", []],
+                                            ["foo", ['foo	src.py	/^    def foo(self):$/;"	kind:member	line:32	class:Goo']]
+                                        ]
                                     }
                                 };
                         }

--- a/src/providers/ctags_definition_provider.test.js
+++ b/src/providers/ctags_definition_provider.test.js
@@ -1,4 +1,7 @@
+const vscode = require("vscode");
+
 const { CtagsDefinitionProvider } = require("./ctags_definition_provider");
+const { reindexScope } = require("../index");
 
 const position = Symbol("position");
 const wordRange = Symbol("wordRange");
@@ -20,24 +23,16 @@ function makeDocumentWithSymbol(detectedSymbol) {
 describe(CtagsDefinitionProvider, () => {
     describe("provideDefinition", () => {
         const stash = {
-            context: {
-                workspaceState: {
-                    get: (key) => {
-                        switch (key) {
-                            case "indexes":
-                                return {
-                                    "/test": {
-                                        symbolIndex: [
-                                            ["emptyListSymbol", []],
-                                            ["foo", ['foo	src.py	/^    def foo(self):$/;"	kind:member	line:32	class:Goo']]
-                                        ]
-                                    }
-                                };
-                        }
-                    }
-                }
-            }
+            context: { workspaceState: new vscode.Memento() }
         };
+        stash.context.workspaceState.update("indexes", {
+            "/test": {
+                symbolIndex: [
+                    ["emptyListSymbol", []],
+                    ["foo", ['foo	src.py	/^    def foo(self):$/;"	kind:member	line:32	class:Goo']]
+                ]
+            }
+        });
 
         it("returns nothing when no definitions are found", async () => {
             const document = makeDocumentWithSymbol("unknownSymbol");

--- a/src/providers/ctags_document_symbol_provider.js
+++ b/src/providers/ctags_document_symbol_provider.js
@@ -13,7 +13,7 @@ class CtagsDocumentSymbolProvider {
         const scope = determineScope(document);
         const { documentIndex } = await getIndexForScope(this.stash, scope);
 
-        const definitions = documentIndex[relativePath];
+        const definitions = new Map(documentIndex).get(relativePath);
         if (definitions) {
             return definitions.map(definition => definitionToSymbolInformation(definition, scope));
         }

--- a/src/providers/ctags_document_symbol_provider.test.js
+++ b/src/providers/ctags_document_symbol_provider.test.js
@@ -9,24 +9,16 @@ function makeDocumentWithPath(fsPath) {
 describe(CtagsDocumentSymbolProvider, () => {
     describe("provideDocumentSymbols", () => {
         const stash = {
-            context: {
-                workspaceState: {
-                    get: (key) => {
-                        switch (key) {
-                            case "indexes":
-                                return {
-                                    "/test": {
-                                        documentIndex: [
-                                            ["empty", []],
-                                            ["foo", ['foo	src.py	/^    def foo(self):$/;"	kind:member	line:32	class:Goo']],
-                                        ]
-                                    }
-                                };
-                        }
-                    }
-                }
-            }
+            context: { workspaceState: new vscode.Memento() }
         };
+        stash.context.workspaceState.update("indexes", {
+            "/test": {
+                documentIndex: [
+                    ["empty", []],
+                    ["foo", ['foo	src.py	/^    def foo(self):$/;"	kind:member	line:32	class:Goo']],
+                ]
+            }
+        });
 
         it("returns nothing when no definitions are found", async () => {
             const document = makeDocumentWithPath("/test/unknown");

--- a/src/providers/ctags_document_symbol_provider.test.js
+++ b/src/providers/ctags_document_symbol_provider.test.js
@@ -16,10 +16,10 @@ describe(CtagsDocumentSymbolProvider, () => {
                             case "indexes":
                                 return {
                                     "/test": {
-                                        documentIndex: {
-                                            empty: [],
-                                            foo: ['foo	src.py	/^    def foo(self):$/;"	kind:member	line:32	class:Goo']
-                                        }
+                                        documentIndex: [
+                                            ["empty", []],
+                                            ["foo", ['foo	src.py	/^    def foo(self):$/;"	kind:member	line:32	class:Goo']],
+                                        ]
                                     }
                                 };
                         }

--- a/src/providers/ctags_workspace_symbol_provider.js
+++ b/src/providers/ctags_workspace_symbol_provider.js
@@ -20,7 +20,7 @@ class CtagsWorkspaceSymbolProvider {
         const matcher = this.getMatcher(query);
 
         return indexes.flatMap(([scope, { symbolIndex }]) => {
-            return Object.entries(symbolIndex)
+            return symbolIndex
                 .filter(([symbol]) => matcher(symbol.toLowerCase()))
                 .flatMap(([_, definitions]) => definitions)
                 .map(definition => definitionToSymbolInformation(definition, scope));

--- a/src/providers/ctags_workspace_symbol_provider.test.js
+++ b/src/providers/ctags_workspace_symbol_provider.test.js
@@ -2,36 +2,29 @@ const vscode = require("vscode");
 
 const { CtagsWorkspaceSymbolProvider } = require("./ctags_workspace_symbol_provider");
 
-const symbolIndex = [
-    ["empty", []],
-    ["fizz", ['fizz	fizz.py	/^fizz = "fizz"$/;"	kind:variable	line:100']],
-    ["multi", [
-        'multi	multi1.py	/^multi = "multi"$/;"	kind:variable	line:200',
-        'multi	multi2.py	/^multi = "multi"$/;"	kind:variable	line:300',
-    ]],
-    ["KONSTANT", ['KONSTANT	konstant.py	/^KONSTANT = "KONSTANT"$/;"	kind:variable	line:100']],
-    ["Klass", ['Klass	klass.py	/^class Klass:$/;"	kind:class	line:200']],
-    ["symbol_with_underscores", [
-        'symbol_with_underscores	underscores.py	/^symbol_with_underscores = "?"$/;"	kind:variable	line:100'
-    ]],
-];
 
 describe(CtagsWorkspaceSymbolProvider, () => {
     describe("provideWorkspaceSymbols", () => {
         const stash = {
-            context: {
-                workspaceState: {
-                    get: (key) => {
-                        switch (key) {
-                            case "indexes":
-                                return {
-                                    "/test": { symbolIndex }
-                                };
-                        }
-                    }
-                }
-            }
+            context: { workspaceState: new vscode.Memento() }
         };
+        stash.context.workspaceState.update("indexes", {
+            "/test": {
+                symbolIndex: [
+                    ["empty", []],
+                    ["fizz", ['fizz	fizz.py	/^fizz = "fizz"$/;"	kind:variable	line:100']],
+                    ["multi", [
+                        'multi	multi1.py	/^multi = "multi"$/;"	kind:variable	line:200',
+                        'multi	multi2.py	/^multi = "multi"$/;"	kind:variable	line:300',
+                    ]],
+                    ["KONSTANT", ['KONSTANT	konstant.py	/^KONSTANT = "KONSTANT"$/;"	kind:variable	line:100']],
+                    ["Klass", ['Klass	klass.py	/^class Klass:$/;"	kind:class	line:200']],
+                    ["symbol_with_underscores", [
+                        'symbol_with_underscores	underscores.py	/^symbol_with_underscores = "?"$/;"	kind:variable	line:100'
+                    ]],
+                ]
+            }
+        });
 
         it.each([undefined, null, ""])("returns nothing when query is falsy", async (query) => {
             const provider = new CtagsWorkspaceSymbolProvider(stash);

--- a/src/providers/ctags_workspace_symbol_provider.test.js
+++ b/src/providers/ctags_workspace_symbol_provider.test.js
@@ -2,19 +2,19 @@ const vscode = require("vscode");
 
 const { CtagsWorkspaceSymbolProvider } = require("./ctags_workspace_symbol_provider");
 
-const symbolIndex = {
-    empty: [],
-    fizz: ['fizz	fizz.py	/^fizz = "fizz"$/;"	kind:variable	line:100'],
-    multi: [
+const symbolIndex = [
+    ["empty", []],
+    ["fizz", ['fizz	fizz.py	/^fizz = "fizz"$/;"	kind:variable	line:100']],
+    ["multi", [
         'multi	multi1.py	/^multi = "multi"$/;"	kind:variable	line:200',
         'multi	multi2.py	/^multi = "multi"$/;"	kind:variable	line:300',
-    ],
-    KONSTANT: ['KONSTANT	konstant.py	/^KONSTANT = "KONSTANT"$/;"	kind:variable	line:100'],
-    Klass: ['Klass	klass.py	/^class Klass:$/;"	kind:class	line:200'],
-    symbol_with_underscores: [
+    ]],
+    ["KONSTANT", ['KONSTANT	konstant.py	/^KONSTANT = "KONSTANT"$/;"	kind:variable	line:100']],
+    ["Klass", ['Klass	klass.py	/^class Klass:$/;"	kind:class	line:200']],
+    ["symbol_with_underscores", [
         'symbol_with_underscores	underscores.py	/^symbol_with_underscores = "?"$/;"	kind:variable	line:100'
-    ],
-};
+    ]],
+];
 
 describe(CtagsWorkspaceSymbolProvider, () => {
     describe("provideWorkspaceSymbols", () => {


### PR DESCRIPTION
Bug report: https://github.com/gediminasz/ctags-companion/issues/15

Use `Map` instead of a plain JS obejct (`{}`).