### PR TITLE
support absolute tags path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,13 +16,14 @@ async function reindexAll(extension) {
 
 async function reindexScope(extension, scope, { fs = fs_, readline = readline_ } = {}) {
     console.time("[Ctags Companion] reindex");
+    const configPath = getConfiguration(scope).get("path")
 
-    const tagsPath = path.join(scope.uri.fsPath, getConfiguration(scope).get("path"));
+    const tagsPath = configPath.startsWith('/') ? vscode.Uri.parse(configPath) : vscode.Uri.joinPath(scope.uri.fsPath, configPath);
 
     if (!fs.existsSync(tagsPath)) {
         extension.statusBarItem.text = (
-            `$(warning) Ctags Companion: file ${getConfiguration(scope).get("path")} not found, ` +
-            'you may need rerun "rebuild ctags" task'
+            `$(warning) Ctags Companion: file ${tagsPath)} not found, ` +
+            'you may need rerun "rebuild ctags" task or adjust the "ctags-companion.path" setting'
         );
         extension.statusBarItem.show();
         return;


### PR DESCRIPTION
note: this PR is _not_ tested (not even "does it compile"), it likely should get a new test case and a ChangeLog entry, but I wanted to at least provide this amount of changes for the issue I see - the setting is obviously not supporting absolute file names yet (but returning the config name as-is in the message)