### PR TITLE
Log errors to output channel instead of a toast message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+- `readtags` and `ctags` execution errors are now logged to "Ctags Companion" output channel instead of toast notifications.
+
 ## 2023.10.2
 
 - Removed reference to no longer functional reindex command.

--- a/src/__mocks__/vscode.js
+++ b/src/__mocks__/vscode.js
@@ -29,11 +29,13 @@ const workspace = {
 console.assert(workspace.asRelativePath({ fsPath: "/test/foo" }) == "foo");
 console.assert(workspace.asRelativePath({ fsPath: "/elsewhere/bar" }) == "/elsewhere/bar");
 
+const mockOutputChannel = {
+    appendLine: jest.fn(),
+};
+
 const window = {
     showErrorMessage: jest.fn(),
-    createOutputChannel: () => ({
-        appendLine() { }
-    })
+    createOutputChannel: () => mockOutputChannel
 };
 
 function Position(line, character) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -99,13 +99,14 @@ function findField(tags, prefix) {
     return tag && tag.substring(prefix.length);
 }
 
+const outputChannel = vscode.window.createOutputChannel(EXTENSION_NAME);
+
 function wrapExec(exec, platform = process.platform) {
-    const outputChannel = vscode.window.createOutputChannel(EXTENSION_NAME);
     return async (command, options) => {
         try {
             if (platform === "win32") {
                 // Use PowerShell on Windows because Command Prompt does not support single quotes
-                options = {...options, shell: "powershell.exe"}
+                options = { ...options, shell: "powershell.exe" };
             }
 
             outputChannel.appendLine(`${command} ${JSON.stringify(options)}`);
@@ -114,7 +115,7 @@ function wrapExec(exec, platform = process.platform) {
             const output = stdout.trim();
             return output ? output.split('\n') : [];
         } catch ({ message }) {
-            vscode.window.showErrorMessage(`${EXTENSION_NAME}: ${message}`);
+            outputChannel.appendLine(message);
             return [];
         }
     };

--- a/src/helpers.test.js
+++ b/src/helpers.test.js
@@ -104,10 +104,10 @@ describe('wrapExec', () => {
         };
 
         const result = await wrapExec(exec)();
-
         expect(result).toEqual([]);
+
         const outputChannel = vscode.window.createOutputChannel();
-        expect(outputChannel.appendLine).toHaveBeenCalledWith("epic fail");
+        expect(outputChannel.appendLine).toHaveBeenLastCalledWith("epic fail");
     });
 
     it.each([

--- a/src/helpers.test.js
+++ b/src/helpers.test.js
@@ -106,7 +106,8 @@ describe('wrapExec', () => {
         const result = await wrapExec(exec)();
 
         expect(result).toEqual([]);
-        expect(vscode.window.showErrorMessage).toHaveBeenCalledWith("Ctags Companion: epic fail");
+        const outputChannel = vscode.window.createOutputChannel();
+        expect(outputChannel.appendLine).toHaveBeenCalledWith("epic fail");
     });
 
     it.each([


### PR DESCRIPTION
https://github.com/gediminasz/ctags-companion/issues/43

